### PR TITLE
Update check_mrpe to work from Docker

### DIFF
--- a/agent-local/check_mrpe
+++ b/agent-local/check_mrpe
@@ -54,7 +54,7 @@ else
   SED_CMD="s/(.*) \(.*\) [0-9] \(.*\)/\1 \2/p"
 fi
 
-for i in $($BIN_NC -w 1 "$Hval" "$pval" 2>&1 | $BIN_SED '/^<<<mrpe>>>/,/^<<</{//!b};d') ; do
+for i in $($BIN_NC -w 1 "$Hval" "$pval" 2>&1 | $BIN_SED '/^<<<mrpe>>>/,/^<<</d') ; do
   echo "$i" | $BIN_SED -n "$SED_CMD"
   if [ "$aflag" ];
   then


### PR DESCRIPTION
Running check_mrpe from inside the LibreNMS Docker container. was giving me this error:

`sed: unterminated {`

Oddly., it seemed OK from outside the container. Perhaps an incompatible sed version.

This small change fixes it.